### PR TITLE
First cut.

### DIFF
--- a/forums/raw-ng-list.txt
+++ b/forums/raw-ng-list.txt
@@ -7,20 +7,7 @@ mozilla.governance                      Governance of the Mozilla Project. (Mode
 
 :Projectwide Forums
 
-mozilla.affiliates                      The Mozilla Affiliates program, encouraging people to spread the news about Firefox and other Mozilla software (Moderated)
-mozilla.education                       For Mozilla's education initiatives. (Moderated)
-mozilla.evangelism                      Spreading the word. (Moderated)
 mozilla.general                         For everything with no forum of its own: discussion about any and all aspects of all the things that we're doing here at mozilla.org (high traffic; often off-topic).
-mozilla.jobs                            For use by those interested in hiring folks to work on Mozilla-related projects as well as by those seeking such work. (Moderated)
-mozilla.join                            The Join Mozilla public engagement initiative
-mozilla.learning-center                 Resources for Mozillians to learn about Mozilla (Moderated)
-mozilla.legal                           For discussions about the <a href="/MPL/">licensing terms</a> of the Mozilla source code and other legal issues. (Moderated)
-mozilla.marketing                       Our plans for world domination. (Moderated)
-mozilla.moss                            For discussions about <a href="http://wiki.mozilla.org/MOSS">Mozilla Open Source Support</a> (MOSS). (Moderated)
-mozilla.mozillians                      For discussions about how to <a href="http://wiki.mozilla.org/Grow">grow Mozilla</a> and bring in new contributors.
-mozilla.privacy                         Forum for discussion of privacy issues and Mozilla's response. (Moderated)
-mozilla.tools                           Discussion of the software development tools the Mozilla project uses (Hg, buildbot, Tinderbox, bonsai...) (Moderated)
-mozilla.wishlist                        For discussions of future ideas, ranging from the practical to the far out.
 
 :Applications and Projects
 
@@ -28,15 +15,6 @@ firefox-dev                             For development of Firefox, a lightweigh
 mozilla.dev.apps.thunderbird            For development of Thunderbird, an email client built on the Mozilla platform.
 tb-planning                             For development of Thunderbird, an email client built on the Mozilla platform.
 mobile-firefox-dev                      For discussions about the <a href="http://wiki.mozilla.org/Mobile">Mozilla platform on mobile devices</a>, e.g. Firefox for Android.
-mozilla.dev.fxos                        For development of all parts of Firefox OS, Mozilla's effort to build a mobile platform powered by the Open Web. (Moderated)
-mozilla.dev.marketplace                 For development of the Mozilla Marketplace and addons.mozilla.org. (Moderated)
-mozilla.dev.webapps                     For development of our Open Web Apps site and ecosystem. (Moderated)
-mozilla.dev.identity                    Identity in the browser (BrowserID/Mozilla Persona)
-mozilla.dev.apps.bugzilla               For development of the Bugzilla bug-tracking system (for support, see <a href="#support-bugzilla">mozilla.support.bugzilla</a>).
-mozilla.dev.apps.calendar               For development of the standard-based <a href="/projects/calendar/">Calendar</a> projects - Sunbird and Lightning.
-mozilla.dev.apps.chatzilla              For development of the Chatzilla IRC chat extension.
-mozilla.dev.apps.dom-inspector          For development of the DOM Inspector, an extension to help web developers peer inside pages.
-mozilla.dev.apps.seamonkey              This forum is for developers working on <a href="http://www.seamonkey-project.org/">Seamonkey</a>, the community continuation of the Mozilla software suite.
 
 :General Development
 
@@ -44,15 +22,11 @@ mozilla.dev.accessibility               For the work to make Mozilla products ac
 mozilla.activity-stream                 The Firefox "activity stream" feature. (Moderated)
 mozilla.apis                            Providing a uniform interface to mozilla's platform APIs. (Moderated)
 mozilla.autofill                        Discussion forum for Form Autofill and Payment implementation on Firefox (Moderated)
-mozilla.dev.bluetooth                   Bluetooth-related topics
-mozilla.dev.b2gdroid                    B2GDroid is the Android Homescreen version of B2G (Firefox OS). (Moderated)
 mozilla.dev.builds                      For discussions about compiling the source code or improving the build system.
 mozilla.dev.chat                        The real-time chat capabilities in the Mozilla platform (IM, IRC etc.) (Moderated)
 mozilla.dev.community-tools             The tools Mozilla uses to manage its community. (Moderated)
 mozilla.context-graph                   The Firefox "context graph" feature. (Moderated)
 mozilla.dev.decentralization            Data decentralization in and for Mozilla services.
-mozilla.dev.flyweb                      <a href="https://wiki.mozilla.org/FlyWeb">FlyWeb is a project which aims to enable websites to discover, connect to, and directly communicate with other nearby web-enabled devices (Moderated)
-mozilla.dev.fxos.sync                   Syncing Firefox OS data (contacts, calendar etc.) with online servers. (Moderated)
 mozilla.dev.geolocation                 Development of geolocation services. (Moderated)
 mozilla.dev.js-sourcemap                The JS sourcemap project, which maps obfuscated JS back to the original version for debugging. (Moderated)
 mozilla.dev.l10n                        For <a href="https://wiki.mozilla.org/L10n:Home_Page">localization</a> (L10N) issues. L10N is the process of adapting software to a specific language and culture (see also <a href="#mozilla-i18n">internationalization</a>).
@@ -79,8 +53,6 @@ mozilla.dev.static-analysis             For discussion about Pork, Dehydra, rewr
 mozilla.dev.super-review                This forum is a mirror of the <a href="/hacking/reviewers.html">super-review</a> mailing list. Requests for patch review and change of review status in Bugzilla are automatically posted here. (Moderated)
 mozilla.dev.telemetry-alerts            Automated alerts from our telemetry monitors. (Moderated)
 mozilla.dev.themes                      For theme developers.
-mozilla.dev.tree-alerts                 Automated messages about continuous build issues. (Moderated)
-mozilla.dev.tree-management.tracemonkey For management of the separate tracemonkey tree
 mozilla.dev.ui-alerts                   Automated messages about UI changes. (Moderated)
 mozilla.dev.usability                   For discussions on user interface and usability issues, including future directions, cross-platform consistency, and so on. (Moderated)
 mozilla.dev.version-control             For discussion about the use of version control systems within Mozilla. (Moderated)
@@ -129,7 +101,6 @@ mozilla.dev.ports.os2                   For discussions about <a href="/ports/os
 
 mozilla.dev.quality                     For <a href="https://quality.mozilla.org/">QA</a> discussion, including using Bugzilla, Mozilla testing, and bug triaging. Do not report bugs here.
 mozilla.dev.quality.bd                  QA discussion in Bengali. (Moderated)
-mozilla.qa.webmaker                     QA for Webmaker projects. (Moderated)
 mozilla.bugmasters                      Our intrepid bug handling team. (Moderated)
 mozilla.compatibility                   Web compatibility - making the web safe for standards-compliant browsers, one site at a time. (Moderated)
 
@@ -141,27 +112,14 @@ mozilla.addons.chromebug                Development of Chromebug, a chrome debug
 
 :Web Development
 
-mozilla.webapps                         Web application development (HTML5) for Firefox OS and the Open Web. (Moderated)
 mozilla.dev.webdev                      Mozilla's web development team. (Moderated)
 mozilla.dev.mozilla-org                 For people working on the mozilla.org website.
 mozilla.community.local-sites           For development of local Mozilla community websites. (Moderated)
 
 :Mozilla Initiatives
 
-mozilla.community.drumbeat              Main Drumbeat newsgroup
-mozilla.drumbeat.website                For people working on <a href="http://www.drumbeat.org/">www.drumbeat.org</a>
-mozilla.drumbeat.privacy-icons          Drumbeat project: Privacy Icons
-mozilla.drumbeat.barcelona              Drumbeat community in Barcelona
-mozilla.drumbeat.festival               Organization of the yearly Drumbeat Festival
-mozilla.community.ignite                Mozilla's involvement in the <a href="https://mozillaignite.org/">US Ignite</a> project. (Moderated)
-mozilla.community.mojo                  The Knight-Mozilla News Technology Initiative - Mozilla and Journalism, or MoJo.
-mozilla.dev.popcorn                     Development of popcorn.js, the HTML5 video toolkit. (Moderated)
 mozilla.mdn.services                    Mailing list for discussing MDN Services project
 mozilla.participation.infrastructure    Discussion and announcements around Participation Infrastructure tools and initiatives.
-mozilla.webmaker                        The Webmaker initiative - teaching the world to hack the web. (Moderated)
-mozilla.webmaker.brasil                 Webmaker initiative in Brazil. (Moderated)
-mozilla.webmaker.canada.bc              Webmaker initiative in British Columbia, Canada. (Moderated)
-mozilla.webmaker.l10n                   Localization of Webmaker content. (Moderated)
 
 :Regional
 
@@ -270,7 +228,6 @@ mozilla.community.crafting              Mozillians making craft-y things. (Moder
 mozilla.community.devderby              The Mozilla monthly Developer Derby for web developers. (Moderated)
 mozilla.community.digital-freedom       Discussion of, and resistance to, laws which work against Mozilla's mission. (Moderated)
 mozilla.community.diversity             A group to plan, build, teach, empower, and grow our diversity skills project-wide. (Moderated)
-mozilla.cbt.education                   Community Building Team - Education group.
 
 :End-User Support
 


### PR DESCRIPTION
This cut culls a number of stale, outdated or otherwise moribund newsgroups from the Forums page, pending a rewrite that broadly directs people towards more modern forums like Discourse.