### PR TITLE
Add 'Glob' to my name.

### DIFF
--- a/credits/names.csv
+++ b/credits/names.csv
@@ -861,7 +861,7 @@ Jason Johnston,johnston
 Martin Joné,jone
 Alan S. Jones,jones
 Brian Jones,jones
-Byron Jones,jones
+Byron 'Glob' Jones,jones
 Dewi Jones,jones
 Jeffrey Jones,jones
 Ryan Jones,jones


### PR DESCRIPTION
Some time ago I switched to using Glob as my Preferred Name at work, which has resulted in someone pointing out that I'm not listed in about:credits.

Rather than replace my legal name with Glob, I've added it as an alias.